### PR TITLE
ci: require newer node for pyright 2

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -17,6 +17,8 @@
 
 Cython
 importlib-resources
+# nodejs is required by pyright
+nodejs >=13.0.0
 pandas
 pyarrow>=8.0.0
 pyright


### PR DESCRIPTION
Fixes #1659.